### PR TITLE
Switch littlefs submodule on WS fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "main/littlefs"]
 	path = src/littlefs
-	url = https://github.com/littlefs-project/littlefs.git
+	url = https://github.com/woodenshark/littlefs.git
 [submodule "mklittlefs"]
 	path = mklittlefs
 	url = https://github.com/BrianPugh/mklittlefs.git


### PR DESCRIPTION
Need to apply patch from https://github.com/littlefs-project/littlefs/issues/268